### PR TITLE
Fix setting Y pos in Positioning menu

### DIFF
--- a/EC-Autoclicker.ahk
+++ b/EC-Autoclicker.ahk
@@ -1022,7 +1022,7 @@ Start(*) {
                     . " " Random(currentConfig.Positioning_YMinPos_NumEdit, currentConfig.Positioning_YMaxPos_NumEdit)
         }
 
-        Click coords buttonClickData
+        Click coords, buttonClickData
 
         AutoclickerGui["StatusBar"].SetText(" Clicks: " (++clickCount))
         AutoclickerGui["StatusBar"].SetText("Elapsed: " Round((A_TickCount - timeStarted) / 1000, 2), 2)


### PR DESCRIPTION
Without this comma, even if I set a Y position, it always chooses 1 as my Y position.